### PR TITLE
feat: enable outputOptions for *FileNames

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,10 +91,10 @@ export const chromeExtension = (
         },
         outputOptions(options) {
             return {
-                ...options,
                 chunkFileNames: "[name].[hash].js",
                 assetFileNames: "[name].[hash].[ext]",
-                entryFileNames: "[name].js"
+                entryFileNames: "[name].js",
+                ...options
             };
         },
         async generateBundle(options, bundle, isWrite) {


### PR DESCRIPTION
Allow custom to override the `chunkFileNames`, `assetsFileNames`, `entryFileNames` for `outputOptions` by options from configuration.