### PR TITLE
update management permission regex

### DIFF
--- a/src/manifest-input/manifest-parser/permissions.ts
+++ b/src/manifest-input/manifest-parser/permissions.ts
@@ -64,7 +64,7 @@ export const idle = (s: string) =>
 export const idltest = (s: string) =>
     /((chromep?)|(browser))[\s\n]*\.[\s\n]*idltest/.test(s);
 export const management = (s: string) =>
-    /((chromep?)|(browser))[\s\n]*\.[\s\n]*management/.test(s);
+    /((chromep?)|(browser))[\s\n]*\.[\s\n]*management(?!\s\n*\.(getSelf|uninstallSelf|getPermissionWarningsByManifest))/.test(s);
 export const nativeMessaging = (s: string) =>
     /((chromep?)|(browser))[\s\n]*\.[\s\n]*nativeMessaging/.test(s);
 export const notifications = (s: string) =>


### PR DESCRIPTION
Issue with details can be found here: https://github.com/StarkShang/vite-plugin-chrome-extension/issues/22

[New regex for checking if code is using the management module](https://regex101.com/r/6doQa9/1/)

There is something more missing, because adding  this code to `examples\background\dist\background.js`
```js
chrome.management.getSelf(() => {
// my code
})
```
and running the build
```shell
yarn; yarn build;
cd examples/background
yarn;yarn build;
```

still adds `management` into `examples\background\dist\manifest.json`


I'm still unsure how exactly code in file `src\manifest-input\manifest-parser\permissions.ts` is being used