### PR TITLE
Change title Vue to Svelte

### DIFF
--- a/examples/svelte/src/manifest.json
+++ b/examples/svelte/src/manifest.json
@@ -9,7 +9,7 @@
             "48": "assets/icon48.png",
             "128": "assets/icon128.png"
         },
-        "default_title": "Vue Popup"
+        "default_title": "Svelte Popup"
     },
     "icons": {
         "16": "assets/icon16.png",


### PR DESCRIPTION
Title seems to have been set to Vue from a separate demo. Updated to reflect Svelte demo.