### PR TITLE
fix(watch-mode): allow run plugin in watch mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export const chromeExtension = (
     const validate = v();
     let manifest: ChromeExtensionManifest | undefined;
     let viteConfig: ResolvedConfig;
+    let isBuilded = false;
 
     /* ----------------- RETURN PLUGIN ----------------- */
     return {
@@ -51,6 +52,10 @@ export const chromeExtension = (
             // Do not reload manifest without changes
             if (!manifestProcessor.manifest) {
                 manifest = manifestProcessor.load(options);
+                options.input = manifestProcessor.resolveInput(options.input);
+            }
+            // Rebuild input if the function is executed more than one time (watch mode)
+            if(manifestProcessor.manifest && isBuilded) {
                 options.input = manifestProcessor.resolveInput(options.input);
             }
             // resolve scripts and assets in html


### PR DESCRIPTION
Fixes: https://github.com/StarkShang/vite-plugin-chrome-extension/issues/6

The problem with the watch mode was that the input for content script was not regenerated and the new manifest was wrong generated because the content script was not found in the bundle as a file.

@StarkShang Would you be open to review and release a new version in case you are agree with the fix or do you prefer that i fork the repo and maintain my own plugin?